### PR TITLE
feat(kustomize): Update ml-workspace options

### DIFF
--- a/kustomize/jupyter-web-app/base/config-map.yaml
+++ b/kustomize/jupyter-web-app/base/config-map.yaml
@@ -29,8 +29,7 @@ data:
           - k8scc01covidacr.azurecr.io/geomatics-notebook-cpu:e2981d65b5ceecaea3d161704632f4a881f18de2
           - k8scc01covidacr.azurecr.io/machine-learning-notebook-cpu:e2981d65b5ceecaea3d161704632f4a881f18de2
           - k8scc01covidacr.azurecr.io/machine-learning-notebook-gpu:e2981d65b5ceecaea3d161704632f4a881f18de2
-          - k8scc01covidacr.azurecr.io/ml-workspace-cpu:f05e40724d31c88153255b02c07eae6a6916b092
-          - k8scc01covidacr.azurecr.io/ml-workspace-gpu:f05e40724d31c88153255b02c07eae6a6916b092
+          - k8scc01covidacr.azurecr.io/ml-workspace-rstudio:test
         # By default, custom container Images are allowed
         # Uncomment the following line to only enable standard container Images
         readOnly: false

--- a/kustomize/jupyter-web-app/base/config-map.yaml
+++ b/kustomize/jupyter-web-app/base/config-map.yaml
@@ -29,7 +29,7 @@ data:
           - k8scc01covidacr.azurecr.io/geomatics-notebook-cpu:e2981d65b5ceecaea3d161704632f4a881f18de2
           - k8scc01covidacr.azurecr.io/machine-learning-notebook-cpu:e2981d65b5ceecaea3d161704632f4a881f18de2
           - k8scc01covidacr.azurecr.io/machine-learning-notebook-gpu:e2981d65b5ceecaea3d161704632f4a881f18de2
-          - k8scc01covidacr.azurecr.io/ml-workspace-rstudio:test
+          - k8scc01covidacr.azurecr.io/ml-workspace-rstudio:8434ec0d63929e4014c4552031a2244ad155e737
         # By default, custom container Images are allowed
         # Uncomment the following line to only enable standard container Images
         readOnly: false


### PR DESCRIPTION
Updates the ml-workspace options in the drop-down to remove the root cpu and gpu ml-workspace images and replace them with the latest non-root cpu ml-workspace image, with rstudio, for next week's hackathon. If a different tag is more appropriate, let me know. This image will eventually be replaced with one or more that incorporate fixes [requested in the minimization PR](https://github.com/StatCan/kubeflow-containers/pull/34), but that is out of scope for the hackathon.