### PR TITLE
fix(ml-workspace-rstudio): fix disappearing tools

### DIFF
--- a/kustomize/jupyter-web-app/base/config-map.yaml
+++ b/kustomize/jupyter-web-app/base/config-map.yaml
@@ -29,7 +29,7 @@ data:
           - k8scc01covidacr.azurecr.io/geomatics-notebook-cpu:e2981d65b5ceecaea3d161704632f4a881f18de2
           - k8scc01covidacr.azurecr.io/machine-learning-notebook-cpu:e2981d65b5ceecaea3d161704632f4a881f18de2
           - k8scc01covidacr.azurecr.io/machine-learning-notebook-gpu:e2981d65b5ceecaea3d161704632f4a881f18de2
-          - k8scc01covidacr.azurecr.io/ml-workspace-rstudio:172993f4a400fcf486050ea7bccc47f475ab2985
+          - k8scc01covidacr.azurecr.io/ml-workspace-rstudio:397fa71aaff9f01cb4638f858799d82566a927fa
         # By default, custom container Images are allowed
         # Uncomment the following line to only enable standard container Images
         readOnly: false

--- a/kustomize/jupyter-web-app/base/config-map.yaml
+++ b/kustomize/jupyter-web-app/base/config-map.yaml
@@ -29,7 +29,7 @@ data:
           - k8scc01covidacr.azurecr.io/geomatics-notebook-cpu:e2981d65b5ceecaea3d161704632f4a881f18de2
           - k8scc01covidacr.azurecr.io/machine-learning-notebook-cpu:e2981d65b5ceecaea3d161704632f4a881f18de2
           - k8scc01covidacr.azurecr.io/machine-learning-notebook-gpu:e2981d65b5ceecaea3d161704632f4a881f18de2
-          - k8scc01covidacr.azurecr.io/ml-workspace-rstudio:8434ec0d63929e4014c4552031a2244ad155e737
+          - k8scc01covidacr.azurecr.io/ml-workspace-rstudio:172993f4a400fcf486050ea7bccc47f475ab2985
         # By default, custom container Images are allowed
         # Uncomment the following line to only enable standard container Images
         readOnly: false


### PR DESCRIPTION
Updates the ml-workspace-rstudio image with a [hotfix](https://github.com/StatCan/kubeflow-desktop/pull/1) for the disappearing "Open Tools" dropdown. The issue was that whenever a Workspace Volume was mounted, the home directory was overwritten, wiping the configurations within. In this fix, the contents of the home directory are copied out and pasted back in.