### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
         CLIENT_ID: "${{ secrets.CLIENT_ID }}"
         APPLICATION_SECRET: "${{ secrets.APPLICATION_SECRET }}"
         
-    # Run kubectl: Remove control-plane label to prevent OPA from managing the namespace 
+    # Run kubectl: Remove control-plane label to allow OPA to manage the namespace 
     - name: kubectl
       uses: statcan/actions/kubectl@master
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,3 +78,16 @@ jobs:
         OIDC_AUTH_URL: "${{ secrets.OIDC_AUTH_URL }}"
         CLIENT_ID: "${{ secrets.CLIENT_ID }}"
         APPLICATION_SECRET: "${{ secrets.APPLICATION_SECRET }}"
+        
+    # Run kubectl: Remove control-plane label to prevent OPA from managing the namespace 
+    - name: kubectl
+      uses: statcan/actions/kubectl@master
+      with:
+        kubeconfig: ${{ secrets.KUBECONFIG }}
+        args: label namespace/kubeflow control-plane-
+      env:
+        OIDC_PROVIDER: "${{ secrets.OIDC_PROVIDER }}"
+        OIDC_REDIRECT_URI: "${{ secrets.OIDC_REDIRECT_URI }}"
+        OIDC_AUTH_URL: "${{ secrets.OIDC_AUTH_URL }}"
+        CLIENT_ID: "${{ secrets.CLIENT_ID }}"
+        APPLICATION_SECRET: "${{ secrets.APPLICATION_SECRET }}"


### PR DESCRIPTION
feat(opa): remove control-plane label that is added when kfctl is run to allow OPA to manage the namespace.

Fixes [#51](https://github.com/StatCan/daaas/issues/51)