### PR TITLE
feat(jupyter): hide registry and version

### DIFF
--- a/kustomize/jupyter-web-app/base/config-map.yaml
+++ b/kustomize/jupyter-web-app/base/config-map.yaml
@@ -35,6 +35,8 @@ data:
         # By default, custom container Images are allowed
         # Uncomment the following line to only enable standard container Images
         readOnly: false
+        hideRegistry: true
+        hideVersion: true
       cpu:
         # CPU for user's Notebook
         value: '0.5'

--- a/kustomize/jupyter-web-app/base/kustomization.yaml
+++ b/kustomize/jupyter-web-app/base/kustomization.yaml
@@ -17,7 +17,7 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/jupyter-web-app
   newName: k8scc01covidacr.azurecr.io/jupyter-web-app
-  newTag: v1.0.0
+  newTag: dcebb21f124814838f49add65b454272fc5d0b62
 configMapGenerator:
 - envs:
   - params.env


### PR DESCRIPTION
Uses a custom jupyter-web-app image to hide the registry and version in the Create Notebook Server image dropdown. 
Resolves #4 