### PR TITLE
feat(notebook): update remote-desktop

### DIFF
--- a/kustomize/jupyter-web-app/base/config-map.yaml
+++ b/kustomize/jupyter-web-app/base/config-map.yaml
@@ -29,8 +29,8 @@ data:
           - k8scc01covidacr.azurecr.io/geomatics-notebook-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b
           - k8scc01covidacr.azurecr.io/machine-learning-notebook-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b
           - k8scc01covidacr.azurecr.io/machine-learning-notebook-gpu:746d058e2f37e004da5ca483d121bfb9e0545f2b
-          - k8scc01covidacr.azurecr.io/remote-desktop-r:428cd1691e075e7fac92980cc534d282e31454d7
-          - k8scc01covidacr.azurecr.io/remote-desktop-geomatics:428cd1691e075e7fac92980cc534d282e31454d7
+          - k8scc01covidacr.azurecr.io/remote-desktop-r:6fb4bcafdfc4f754d62fa7de66f05f889dab7428
+          - k8scc01covidacr.azurecr.io/remote-desktop-geomatics:6fb4bcafdfc4f754d62fa7de66f05f889dab7428
           - k8scc01covidacr.azurecr.io/r-studio-cpu:e237dde4e7666d90dc6c69f3673412f1c94e57f4
         # By default, custom container Images are allowed
         # Uncomment the following line to only enable standard container Images


### PR DESCRIPTION
Includes the conda install fix, Mac support for clipboard sharing in Chrome (resolves https://github.com/StatCan/kubeflow-containers/issues/56 and resolves https://github.com/StatCan/kubeflow-containers/issues/57 if my understanding is correct that they come down to the same issue), and miscellaneous minor fixes. Does not include the landing page as that is still being finalized, but it should be ready for the next update.