### PR TITLE
feat(notebook): update remote-desktop

### DIFF
--- a/kustomize/jupyter-web-app/base/config-map.yaml
+++ b/kustomize/jupyter-web-app/base/config-map.yaml
@@ -30,8 +30,8 @@ data:
           - k8scc01covidacr.azurecr.io/machine-learning-notebook-cpu:5ef877ea13789f64594c219ef0a302dc97c21bb4
           - k8scc01covidacr.azurecr.io/machine-learning-notebook-gpu:5ef877ea13789f64594c219ef0a302dc97c21bb4
           - k8scc01covidacr.azurecr.io/r-studio-cpu:5ef877ea13789f64594c219ef0a302dc97c21bb4
-          - k8scc01covidacr.azurecr.io/remote-desktop-r:337a31292531e2ff56be3f07987aab0847d26b53
-          - k8scc01covidacr.azurecr.io/remote-desktop-geomatics:337a31292531e2ff56be3f07987aab0847d26b53
+          - k8scc01covidacr.azurecr.io/remote-desktop-r:9e05d858dcf414415e4637c0e11cbc69d55571a7
+          - k8scc01covidacr.azurecr.io/remote-desktop-geomatics:9e05d858dcf414415e4637c0e11cbc69d55571a7
         # By default, custom container Images are allowed
         # Uncomment the following line to only enable standard container Images
         readOnly: false


### PR DESCRIPTION
Adds LibreOffice Calc version 6.4.6 (latest stable) to the Remote Desktop images