### PR TITLE
fix(jupyter-web-app): Set replicas to 3 for the jupyter-web-app

### DIFF
--- a/kustomize/jupyter-web-app/base/deployment.yaml
+++ b/kustomize/jupyter-web-app/base/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: deployment
 spec:
-  replicas: 1
+  replicas: 3
   template:
     spec:
       containers:


### PR DESCRIPTION
Due to the increased number of API calls, we were starting to see some failures due to load, I propose we increase the number of replicas to 3 by default on the Jupyter Web App deployment. I have already done this manually and it seems to fix the issue.