### PR TITLE
fix: Add image pull secrets to centraldashboard

### DIFF
--- a/kustomize/centraldashboard/base/deployment.yaml
+++ b/kustomize/centraldashboard/base/deployment.yaml
@@ -35,3 +35,5 @@ spec:
         - name: PROFILES_KFAM_SERVICE_HOST
           value: profiles-kfam.kubeflow
       serviceAccountName: centraldashboard
+      imagePullSecrets:
+      - name: k8scc01covidacr-registry-connection


### PR DESCRIPTION
Adds the secret which is required now that the image comes from our own
container registry.