### PR TITLE
Up the RAM and Workspace Volume notebook defaults

### DIFF
--- a/kustomize/jupyter-web-app/base/config-map.yaml
+++ b/kustomize/jupyter-web-app/base/config-map.yaml
@@ -43,7 +43,7 @@ data:
         readOnly: false
       memory:
         # Memory for user's Notebook
-        value: 2.0Gi
+        value: 4.0Gi
         readOnly: false
       workspaceVolume:
         # Workspace Volume to be attached to user's Notebook
@@ -62,7 +62,7 @@ data:
             value: 'workspace-{notebook-name}'
           size:
             # The Size of the Workspace Volume (in Gi)
-            value: '10Gi'
+            value: '32Gi'
           mountPath:
             # The Path that the Workspace Volume will be mounted
             value: /home/jovyan
@@ -71,7 +71,7 @@ data:
             # Supported values: 'ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'
             value: ReadWriteOnce
           class:
-            # The StrageClass the PVC will use if type is New. Special values are:
+            # The StorageClass the PVC will use if type is New. Special values are:
             # {none}: default StorageClass
             # {empty}: empty string ""
             value: '{none}'


### PR DESCRIPTION
The nodes have a 1:4 CPU:RAM ratio, which we are not currently keeping with. (I'm guessing that'll lead to underutilized RAM?)

Also, I have heard reports of Jupyter kernels dying silently, which I am blaming the RAM for (though I do not have evidence.)

The workspace volume bump is partly because I think 10gb is a bit small (and it should be increased to at least 16gb), but also, we're exploring moving conda installs into the workspace volume, so we need space for conda.