### PR TITLE
feat(seldon): Add seldon-core-operator

### DIFF
--- a/kustomize/application/seldon/kustomization.yaml
+++ b/kustomize/application/seldon/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../.cache/manifests/manifests-1.2-branch/seldon/seldon-core-operator/base

--- a/kustomize/stacks/daaas/kustomization.yaml
+++ b/kustomize/stacks/daaas/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - ../../application/pipeline
   - ../../application/profiles
   - ../../application/pytorch-job
+  - ../../application/seldon
   - ../../application/spark-operator
   - ../../application/tf-training
 configMapGenerator:


### PR DESCRIPTION
This seems to have gone missing in the upgrade, so the webhook is still present but the deployment is missing.