### PR TITLE
feat: move to the new remote-desktop

### DIFF
--- a/kustomize/application/jupyter-web-app/configs/spawner_ui_config.yaml
+++ b/kustomize/application/jupyter-web-app/configs/spawner_ui_config.yaml
@@ -25,8 +25,7 @@ spawnerFormDefaults:
       - k8scc01covidacr.azurecr.io/jupyterlab-cpu:f25cad42
       - k8scc01covidacr.azurecr.io/jupyterlab-pytorch:f25cad42
       - k8scc01covidacr.azurecr.io/jupyterlab-tensorflow:f25cad42
-      - k8scc01covidacr.azurecr.io/remote-desktop-r:68e12a3b2fb14307cd9a4cf5989e34ad057da7c5
-      - k8scc01covidacr.azurecr.io/remote-desktop-geomatics:68e12a3b2fb14307cd9a4cf5989e34ad057da7c5
+      - k8scc01covidacr.azurecr.io/remote-desktop:75f84102
     # By default, custom container Images are allowed
     # Uncomment the following line to only enable standard container Images
     readOnly: false


### PR DESCRIPTION
This deprecated the [kubeflow containers desktop](https://github.com/statcan/kubeflow-containers-desktop) repo. We are now 100% on our kubeflow-containers images.