### PR TITLE
fix(gitea): update url

### DIFF
--- a/kustomize/apps/centraldashboard/base/centraldashboard-config.yaml
+++ b/kustomize/apps/centraldashboard/base/centraldashboard-config.yaml
@@ -54,7 +54,7 @@ data:
         },
         {
           "type": "item",
-          "link": "/gitea/",
+          "link": "/gitea-unclassified/",
           "text": "Git",
           "icon": "icons:code"
         }


### PR DESCRIPTION
Updated to match the new classification split, where only unclassified gitea will be accessible through the central dashboard.

The url prefix at the time of this commit is set here: https://github.com/StatCan/aaw-argocd-manifests/blob/aaw-dev-cc-00/daaas-system/profile-controllers/profiles-controller/application.jsonnet#L109