### PR TITLE
add: istio injector labels

### DIFF
--- a/kustomize/apps/profiles/base/kustomization.yaml
+++ b/kustomize/apps/profiles/base/kustomization.yaml
@@ -5,5 +5,10 @@ namespace: kubeflow
 resources:
 - github.com/kubeflow/manifests/apps/profiles/upstream/overlays/kubeflow?ref=v1.3.1
 
+configMapGenerator:
+  - name: namespace-labels-data
+    files:
+      - namespace-labels.yaml
+
 patchesStrategicMerge:
 - deployment.yaml

--- a/kustomize/apps/profiles/base/namespace-labels.yaml
+++ b/kustomize/apps/profiles/base/namespace-labels.yaml
@@ -1,0 +1,5 @@
+istio-injection: "enabled"
+katib.kubeflow.org/metrics-collector-injection: "enabled"
+serving.kubeflow.org/inferenceservice: "enabled"
+pipelines.kubeflow.org/enabled: "true"
+app.kubernetes.io/part-of: "kubeflow-profile"


### PR DESCRIPTION
New namespaces need to have the following labels in order to be able to start new servers/notebooks!

```
istio-injection: "enabled"
katib.kubeflow.org/metrics-collector-injection: "enabled"
serving.kubeflow.org/inferenceservice: "enabled"
pipelines.kubeflow.org/enabled: "true"
app.kubernetes.io/part-of: "kubeflow-profile"
```

**Fixes**: https://github.com/StatCan/daaas/issues/1093

**Tested on dev with**: https://github.com/StatCan/aaw-kubeflow-manifests/pull/184

---

Previous pull request was unacceptable: https://github.com/StatCan/aaw-kubeflow-manifests/pull/186