### PR TITLE
feat(notebook-controller): readiness probe

### DIFF
--- a/kustomize/apps/notebook-controller/base/deployment.yaml
+++ b/kustomize/apps/notebook-controller/base/deployment.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: manager
-        image: gcr.io/kubeflow-images-public/notebook-controller:v1.1.0-gd3377cbd
+        image: k8scc01covidacr.azurecr.io/kubeflow/notebook-controller:0524491606c8c4477d9b2c887948a12d7660a3e4
         command:
           - /manager
         env:


### PR DESCRIPTION
Bring in Salwa's changes to add a readiness probe, this has been live on dev for a couple months now. 
https://github.com/StatCan/aaw-kubeflow-manifests/pull/177
https://github.com/StatCan/daaas/issues/339

I forgot to at least make a PR for this yesterday but did bring it up that it's something that we should probably bring in
CC @chuckbelisle 