### PR TITLE
update: modified upstream kubeflow roles to add RBAC rule for creating argo workflows

### DIFF
--- a/kustomize/common/kubeflow-roles/base/drop-all.yaml
+++ b/kustomize/common/kubeflow-roles/base/drop-all.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /rules
+  value: []

--- a/kustomize/common/kubeflow-roles/base/kubeflow-edit-rules.yaml
+++ b/kustomize/common/kubeflow-roles/base/kubeflow-edit-rules.yaml
@@ -1,0 +1,150 @@
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+    - ""
+    resources:
+    - pods/attach
+    - pods/exec
+    - pods/portforward
+    - pods/proxy
+    - secrets
+    - services/proxy
+    verbs:
+    - get
+    - list
+    - watch
+
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+    - ""
+    resources:
+    - pods
+    - pods/attach
+    - pods/exec
+    - pods/portforward
+    - pods/proxy
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update
+
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - endpoints
+    - persistentvolumeclaims
+    - replicationcontrollers
+    - replicationcontrollers/scale
+    - secrets
+    - serviceaccounts
+    - services
+    - services/proxy
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update
+
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+    - apps
+    resources:
+    - daemonsets
+    - deployments
+    - deployments/rollback
+    - deployments/scale
+    - replicasets
+    - replicasets/scale
+    - statefulsets
+    - statefulsets/scale
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update
+
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+    - batch
+    resources:
+    - cronjobs
+    - jobs
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update
+
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+    - extensions
+    resources:
+    - daemonsets
+    - deployments
+    - deployments/rollback
+    - deployments/scale
+    - replicasets
+    - replicasets/scale
+    - replicationcontrollers/scale
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update
+
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+    - policy
+    resources:
+    - poddisruptionbudgets
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update
+
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+    - networking.k8s.io
+    resources:
+    - ingresses
+    - networkpolicies
+    verbs:
+    - get
+    - list
+    - watch
+
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+    - argoproj.io
+    resources:
+    - workflows
+    verbs:
+    - create
+    - patch 

--- a/kustomize/common/kubeflow-roles/base/kustomization.yaml
+++ b/kustomize/common/kubeflow-roles/base/kustomization.yaml
@@ -3,3 +3,18 @@ kind: Kustomization
 
 resources:
 - github.com/kubeflow/manifests/common/kubeflow-roles/base?ref=v1.3.1
+
+#use logical groups in order to add as many rules to the Kubeflow role
+patchesJson6902:
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRole
+    name: kubeflow-kubernetes-edit
+  path: drop-all.yaml
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRole
+    name: kubeflow-kubernetes-edit
+  path: kubeflow-edit-rules.yaml


### PR DESCRIPTION
Closes [Statcan/daaas#1235](https://github.com/StatCan/daaas/issues/1235)

Copied kustomization.yaml, drop-all.yaml and kubeflow-edit-rules.yaml from aaw-dev-cc-00 branch.