### PR TITLE
upgrade kubeflow-namespace (1.3.1 --> 1.4.1)

### DIFF
--- a/kustomize/common/kubeflow-namespace/base/kustomization.yaml
+++ b/kustomize/common/kubeflow-namespace/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/kubeflow/manifests/common/kubeflow-namespace/base?ref=v1.3.1
+- github.com/kubeflow/manifests/common/kubeflow-namespace/base?ref=v1.4.1
 
 patches:
 - path: namespace_patch.json


### PR DESCRIPTION
This is part of the Kubeflow 1.4 Upgrade Epic (https://github.com/StatCan/daaas/issues/1203) and resolves the following upgrade issue: https://github.com/StatCan/aaw-kubeflow-manifests/issues/198.