### PR TITLE
upgrade kubeflow-roles (1.3.1 --> 1.4.1)

### DIFF
--- a/kustomize/common/kubeflow-roles/base/kustomization.yaml
+++ b/kustomize/common/kubeflow-roles/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/kubeflow/manifests/common/kubeflow-roles/base?ref=v1.3.1
+- github.com/kubeflow/manifests/common/kubeflow-roles/base?ref=v1.4.1
 
 #use logical groups in order to add as many rules to the Kubeflow role
 patchesJson6902:
@@ -10,7 +10,7 @@ patchesJson6902:
     group: rbac.authorization.k8s.io
     version: v1
     kind: ClusterRole
-    name: kubeflow-kubernetes-edit
+    name: kubeflow-kubernetes-edit 
   path: drop-all.yaml
 - target:
     group: rbac.authorization.k8s.io


### PR DESCRIPTION
This is part of the Kubeflow 1.4 Upgrade Epic (https://github.com/StatCan/daaas/issues/1203) and resolves the following upgrade issue: closes https://github.com/StatCan/aaw-kubeflow-manifests/issues/199.