### PR TITLE
upgrade notebook-controller (1.3.1 --> 1.4.1)

### DIFF
--- a/kustomize/apps/notebook-controller/base/kustomization.yaml
+++ b/kustomize/apps/notebook-controller/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/kubeflow/manifests/apps/jupyter/notebook-controller/upstream/overlays/kubeflow?ref=v1.3.1
+- github.com/kubeflow/manifests/apps/jupyter/notebook-controller/upstream/overlays/kubeflow?ref=v1.4.1
 
 patchesStrategicMerge:
 - deployment.yaml


### PR DESCRIPTION
This is part of the Kubeflow 1.4 Upgrade Epic (https://github.com/StatCan/daaas/issues/1203) and resolves the following upgrade issue: https://github.com/StatCan/aaw-kubeflow-manifests/issues/216.