### PR TITLE
upgrade jwa (1.3.1 --> 1.4.1)

### DIFF
--- a/kustomize/apps/jupyter-web-app/base/kustomization.yaml
+++ b/kustomize/apps/jupyter-web-app/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/kubeflow/manifests/apps/jupyter/jupyter-web-app/upstream/overlays/istio?ref=v1.3.1
+- github.com/kubeflow/manifests/apps/jupyter/jupyter-web-app/upstream/overlays/istio?ref=v1.4.1
 - configs/kubeflow-config.yaml
 
 patchesStrategicMerge:


### PR DESCRIPTION
This is part of the Kubeflow 1.4 Upgrade Epic (https://github.com/StatCan/daaas/issues/1203) and resolves the following upgrade issue: closes #204 