### PR TITLE
upgrade(common): kubeflow namespace 1.6

### DIFF
--- a/kustomize/common/kubeflow-namespace/base/kustomization.yaml
+++ b/kustomize/common/kubeflow-namespace/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/kubeflow/manifests/common/kubeflow-namespace/base?ref=v1.4.1
+- github.com/kubeflow/manifests/common/kubeflow-namespace/base?ref=v1.6.0
 
 patches:
 - path: namespace_patch.json


### PR DESCRIPTION
Closes https://github.com/StatCan/aaw-kubeflow-manifests/issues/225