### PR TITLE
feat(pipelines): disable ml-pipeline pods by default

### DIFF
--- a/kustomize/apps/profiles/base/namespace-labels.yaml
+++ b/kustomize/apps/profiles/base/namespace-labels.yaml
@@ -1,5 +1,5 @@
 istio-injection:                       'enabled'
 katib-metricscollector-injection:      'enabled'
 serving.kubeflow.org/inferenceservice: 'enabled'
-pipelines.kubeflow.org/enabled:        'true'
+pipelines.kubeflow.org/enabled:        'false'
 app.kubernetes.io/part-of:             'kubeflow-profile'


### PR DESCRIPTION
Reduce costs by disabling ml-pipeline pods by default in each user's namespace