### PR TITLE
Fix JWA Routing

### DIFF
--- a/kustomize/apps/jupyter-web-app/base/configs/nginx-config.yaml
+++ b/kustomize/apps/jupyter-web-app/base/configs/nginx-config.yaml
@@ -34,31 +34,18 @@ data:
             set $accept_language "en";
         }
 
-        # Redirect "/" to Angular application in the preferred language of the browser
-        # The permanent keyword ensured that the redirect will be a 301 Moved Permanently
-        # HTTP redirect, which means that the old address is no longer valid and will not come back online.
-        rewrite ^/jupyter/(.*)$ /jupyter/$accept_language;
-
-        # If this is a static file request initiated from the index.html file, make sure
-        # the /jupyter/ prefix is added
-        rewrite ^/$accept_language/(.*)$ /jupyter/$accept_language/$1;
+        rewrite ^/jupyter/(.*)$ /$accept_language/$1;
 
         # Rewrite
-        # rewrite ^/jupyter/(fr|en)/api/(.*)$ /jupyter/api/$2;
+        # rewrite ^/(fr|en)/api/(.*)$ /api/$2;
 
-        # Everything under the Angular application is always redirected to Angular in the
-        # correct language
-        location ~ ^/jupyter/(fr|en)$ {
-            try_files $uri/index.html $uri/index.html;
+        location ~ ^/(fr|en)/.*$ {
+            root html;
         }
 
-        location ~ ^/(fr|en)$ {
-            root jupyter;
-        }
-
-        location ~ ^/jupyter/api/.*$ {
-          proxy_pass http://0.0.0.0:5001;
-        }
+        # location ~ ^/jupyter/api/.*$ {
+        #   proxy_pass http://0.0.0.0:5001;
+        # }
 
       }
     }

--- a/kustomize/apps/jupyter-web-app/base/configs/nginx-config.yaml
+++ b/kustomize/apps/jupyter-web-app/base/configs/nginx-config.yaml
@@ -36,16 +36,15 @@ data:
 
         rewrite ^/jupyter/(.*)$ /$accept_language/$1;
 
-        # Rewrite
-        # rewrite ^/(fr|en)/api/(.*)$ /api/$2;
+        rewrite ^/(fr|en)/api/(.*)$ /api/$2;
 
         location ~ ^/(fr|en)/.*$ {
             root html;
         }
 
-        # location ~ ^/jupyter/api/.*$ {
-        #   proxy_pass http://0.0.0.0:5001;
-        # }
+        location ~ ^/api/.*$ {
+          proxy_pass http://0.0.0.0:5001;
+        }
 
       }
     }

--- a/kustomize/apps/jupyter-web-app/base/configs/nginx-config.yaml
+++ b/kustomize/apps/jupyter-web-app/base/configs/nginx-config.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: jwa-nginx-configuration
+  namespace: kubeflow
 data:
   nginx.conf: |
     worker_processes  3;
@@ -17,7 +18,7 @@ data:
       include /etc/nginx/mime.types;
       include mime.types;
 
-      # Browser preferred language detection ( does NOT require     
+      # Browser preferred language detection ( does NOT require
       # AcceptLanguageModule)
       map $http_accept_language $accept_language {
           ~*^fr fr;
@@ -34,24 +35,30 @@ data:
         }
 
         # Redirect "/" to Angular application in the preferred language of the browser
-        # The permanent keyword ensured that the redirect will be a 301 Moved Permanently 
+        # The permanent keyword ensured that the redirect will be a 301 Moved Permanently
         # HTTP redirect, which means that the old address is no longer valid and will not come back online.
-        rewrite ^/$ /$accept_language;
-        
-        # Rewrite 
-        rewrite ^/(fr|en)/api/(.*)$ /api/$2;
+        rewrite ^/jupyter/(.*)$ /jupyter/$accept_language;
+
+        # If this is a static file request initiated from the index.html file, make sure
+        # the /jupyter/ prefix is added
+        rewrite ^/$accept_language/(.*)$ /jupyter/$accept_language/$1;
+
+        # Rewrite
+        # rewrite ^/jupyter/(fr|en)/api/(.*)$ /jupyter/api/$2;
 
         # Everything under the Angular application is always redirected to Angular in the
         # correct language
-        location ~ ^/(fr|en) {
-            try_files $uri /$1/index.html?$args;
+        location ~ ^/jupyter/(fr|en)$ {
+            try_files $uri/index.html $uri/index.html;
         }
-        # ...
 
-        location ~ ^/api/.*$ {
+        location ~ ^/(fr|en)$ {
+            root jupyter;
+        }
+
+        location ~ ^/jupyter/api/.*$ {
           proxy_pass http://0.0.0.0:5001;
         }
 
       }
     }
-    

--- a/kustomize/apps/jupyter-web-app/base/deployment.yaml
+++ b/kustomize/apps/jupyter-web-app/base/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: deployment
 spec:
-  replicas: 1
+  replicas: 3
   template:
     metadata:
       annotations:

--- a/kustomize/apps/jupyter-web-app/base/deployment.yaml
+++ b/kustomize/apps/jupyter-web-app/base/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: deployment
 spec:
-  replicas: 3
+  replicas: 1
   template:
     metadata:
       annotations:
@@ -12,7 +12,7 @@ spec:
       containers:
       - name: jupyter-web-app
         imagePullPolicy: IfNotPresent
-        image: k8scc01covidacr.azurecr.io/jupyter-apis:437dd2596b033f895258e298f9c80741c19e98b8 
+        image: k8scc01covidacr.azurecr.io/jupyter-apis:1931282e965bd08992c22ecf68473bf01233c63a
         env:
         - name: UI
           value: default
@@ -31,7 +31,7 @@ spec:
         - name: KUBECOST_URL
           value: http://kubecost-cost-analyzer.kubecost-system.svc.cluster.local:9090
         ports:
-        - containerPort: 5000
+        - containerPort: 5001
         volumeMounts:
         - name: config-volume
           mountPath: /etc/config
@@ -52,21 +52,21 @@ spec:
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
           - name: static-files
-            mountPath: /etc/nginx/html/
+            mountPath: /etc/nginx/html/jupyter
         ports:
           - name: http
-            containerPort: 8080
+            containerPort: 5000
       serviceAccountName: service-account
       initContainers:
       - name: copy-jwa-static-files
         # Change for the image I just built
-        image: k8scc01covidacr.azurecr.io/jupyter-apis:437dd2596b033f895258e298f9c80741c19e98b8 
+        image: k8scc01covidacr.azurecr.io/jupyter-apis:1931282e965bd08992c22ecf68473bf01233c63a
         # image: k3d-s3proxy-registry:5050/s3proxy-dev:latest
         command: [sh, -c]
-        args: ["cp -r /static/* /etc/nginx/html/"]
+        args: ["mkdir -p /etc/nginx/html/jupyter/ && cp -r /src/dist/frontend/* /etc/nginx/html/jupyter/"]
         imagePullPolicy: IfNotPresent
         volumeMounts:
-          - mountPath: /etc/nginx/html/
+          - mountPath: /etc/nginx/html/jupyter/
             name: static-files
       volumes:
         - name: jwa-nginx-configuration

--- a/kustomize/apps/jupyter-web-app/base/deployment.yaml
+++ b/kustomize/apps/jupyter-web-app/base/deployment.yaml
@@ -12,7 +12,7 @@ spec:
       containers:
       - name: jupyter-web-app
         imagePullPolicy: IfNotPresent
-        image: k8scc01covidacr.azurecr.io/jupyter-apis:1931282e965bd08992c22ecf68473bf01233c63a
+        image: k8scc01covidacr.azurecr.io/jupyter-apis:6d850d61d0862ff95e0d189a128d64b632843a33
         env:
         - name: UI
           value: default
@@ -60,7 +60,7 @@ spec:
       initContainers:
       - name: copy-jwa-static-files
         # Change for the image I just built
-        image: k8scc01covidacr.azurecr.io/jupyter-apis:1931282e965bd08992c22ecf68473bf01233c63a
+        image: k8scc01covidacr.azurecr.io/jupyter-apis:6d850d61d0862ff95e0d189a128d64b632843a33
         # image: k3d-s3proxy-registry:5050/s3proxy-dev:latest
         command: [sh, -c]
         args: ["cp -r /src/dist/frontend/* /etc/nginx/html/"]

--- a/kustomize/apps/jupyter-web-app/base/deployment.yaml
+++ b/kustomize/apps/jupyter-web-app/base/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
           - name: static-files
-            mountPath: /etc/nginx/html/jupyter
+            mountPath: /etc/nginx/html/
         ports:
           - name: http
             containerPort: 5000
@@ -63,10 +63,10 @@ spec:
         image: k8scc01covidacr.azurecr.io/jupyter-apis:1931282e965bd08992c22ecf68473bf01233c63a
         # image: k3d-s3proxy-registry:5050/s3proxy-dev:latest
         command: [sh, -c]
-        args: ["mkdir -p /etc/nginx/html/jupyter/ && cp -r /src/dist/frontend/* /etc/nginx/html/jupyter/"]
+        args: ["cp -r /src/dist/frontend/* /etc/nginx/html/"]
         imagePullPolicy: IfNotPresent
         volumeMounts:
-          - mountPath: /etc/nginx/html/jupyter/
+          - mountPath: /etc/nginx/html/
             name: static-files
       volumes:
         - name: jwa-nginx-configuration

--- a/kustomize/apps/jupyter-web-app/base/kustomization.yaml
+++ b/kustomize/apps/jupyter-web-app/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 patchesStrategicMerge:
 - cluster-role.yaml
 - deployment.yaml
+- vs.yaml
 
 configMapGenerator:
 - files:

--- a/kustomize/apps/jupyter-web-app/base/vs.yaml
+++ b/kustomize/apps/jupyter-web-app/base/vs.yaml
@@ -19,12 +19,6 @@ spec:
         prefix: /en/
     - uri:
         prefix: /fr/
-    # - headers:
-    #     referer:
-    #       exact: https://kubeflow.aaw-dev.cloud.statcan.ca/_/s3/?ns=aaw-fc
-    # - headers:
-    #     referer:
-    #       exact: https://kubeflow.aaw-dev.cloud.statcan.ca/jupyter/
     route:
     - destination:
         host: jupyter-web-app-service.$(JWA_NAMESPACE).svc.$(JWA_CLUSTER_DOMAIN)

--- a/kustomize/apps/jupyter-web-app/base/vs.yaml
+++ b/kustomize/apps/jupyter-web-app/base/vs.yaml
@@ -15,12 +15,16 @@ spec:
     match:
     - uri:
         prefix: /jupyter/
-    - headers:
-        referer:
-          exact: https://kubeflow.aaw-dev.cloud.statcan.ca/_/s3/?ns=aaw-fc
-    - headers:
-        referer:
-          exact: https://kubeflow.aaw-dev.cloud.statcan.ca/jupyter/
+    - uri:
+        prefix: /en/
+    - uri:
+        prefix: /fr/
+    # - headers:
+    #     referer:
+    #       exact: https://kubeflow.aaw-dev.cloud.statcan.ca/_/s3/?ns=aaw-fc
+    # - headers:
+    #     referer:
+    #       exact: https://kubeflow.aaw-dev.cloud.statcan.ca/jupyter/
     route:
     - destination:
         host: jupyter-web-app-service.$(JWA_NAMESPACE).svc.$(JWA_CLUSTER_DOMAIN)

--- a/kustomize/apps/jupyter-web-app/base/vs.yaml
+++ b/kustomize/apps/jupyter-web-app/base/vs.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: jupyter-web-app-jupyter-web-app
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        add:
+          x-forwarded-prefix: /jupyter
+    match:
+    - uri:
+        prefix: /jupyter/
+    - headers:
+        referer:
+          exact: https://kubeflow.aaw-dev.cloud.statcan.ca/_/s3/?ns=aaw-fc
+    - headers:
+        referer:
+          exact: https://kubeflow.aaw-dev.cloud.statcan.ca/jupyter/
+    route:
+    - destination:
+        host: jupyter-web-app-service.$(JWA_NAMESPACE).svc.$(JWA_CLUSTER_DOMAIN)
+        port:
+          number: 80


### PR DESCRIPTION
Several refactors to fix routing to the JWA web application.

**Summary of Changes**

- add virtualservice to our kustomize (need to change routing logic to accommodate front-end changes)
- refactor nginx configuration to remove `jupyter` prefix and handle `en/fr` locales
- update JWA `environment*.ts` to remove the `static` prefix for logo assets (see https://github.com/StatCan/jupyter-apis/commit/6d850d61d0862ff95e0d189a128d64b632843a33)
- fix exposed ports in deployment to align with the ports the service forwards to
- update nginx configuration to listen on port 5000 instead of 8080