### PR TITLE
feat(centraldashboard): update en/fr jupyter links

### DIFF
--- a/kustomize/apps/centraldashboard/base/centraldashboard-config.yaml
+++ b/kustomize/apps/centraldashboard/base/centraldashboard-config.yaml
@@ -12,7 +12,7 @@ data:
         "menuLinks": [
         {
           "type": "item",
-          "link": "/jupyter/",
+          "link": "/en/",
           "text": "Notebooks",
           "icon": "book"
         },
@@ -105,7 +105,7 @@ data:
         "menuLinks": [
         {
           "type": "item",
-          "link": "/jupyter/",
+          "link": "/fr/",
           "text": "Serveur Bloc-notes",
           "icon": "book"
         },


### PR DESCRIPTION
Let's user route to english/french site for jupyter web applications depending on browser language selected.

Closes https://github.com/StatCan/jupyter-apis/issues/170