### PR TITLE
upgrade: seldon core operator v1.15

### DIFF
--- a/kustomize/contrib/seldon/base/kustomization.yaml
+++ b/kustomize/contrib/seldon/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/kubeflow/manifests/contrib/seldon/seldon-core-operator/base?ref=v1.6.0
+- github.com/kubeflow/manifests/contrib/seldon/seldon-core-operator/base?ref=v1.7.0
 
 ## Cert Manager
 patchesJson6902:


### PR DESCRIPTION
Upgrade seldon core in Dev (apart of KF 1.7) V1.15 
Less maintaining to do:
upgrading all ValidatingWebhookConfiguration resources to v1 intead of v1beta1