### PR TITLE
kubeflow: fix training-operator failure and MPIJob issues

### DIFF
--- a/kustomize/apps/training-operator/base/deployment.yaml
+++ b/kustomize/apps/training-operator/base/deployment.yaml
@@ -9,7 +9,7 @@ spec:
       containers:
         - command:
             - /manager
-          image: kubeflow/training-operator
+          image: kubeflow/training-operator:v1-e1434f6
           name: training-operator
           livenessProbe:
             initialDelaySeconds: 35

--- a/kustomize/apps/training-operator/base/deployment.yaml
+++ b/kustomize/apps/training-operator/base/deployment.yaml
@@ -9,6 +9,7 @@ spec:
       containers:
         - command:
             - /manager
+            - --mpi-kubectl-delivery-image=k8scc01covidacrdev.azurecr.io/mpioperator/kubectl-delivery:latest
           image: kubeflow/training-operator:v1-e1434f6
           name: training-operator
           livenessProbe:

--- a/kustomize/apps/training-operator/base/deployment.yaml
+++ b/kustomize/apps/training-operator/base/deployment.yaml
@@ -11,6 +11,12 @@ spec:
             - /manager
           image: kubeflow/training-operator
           name: training-operator
+          livenessProbe:
+            initialDelaySeconds: 35
+            timeoutSeconds: 10
+          readinessProbe:
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
           resources:
             limits:
               cpu: 250m


### PR DESCRIPTION
1. The training-operator deployment fails on startup as there is not enough time for the container to become ready causing a restart loop, solution increase initial delay on readiness probes.
2. Pinned the correct training-operator image that matches kf1.6 release (latest image has a paddle CRD released for 1.7), see https://github.com/kubeflow/manifests/blob/v1.6-branch/apps/training-operator/upstream/overlays/kubeflow/kustomization.yaml
3. The kubectl-delivery container image used by MPIJob wasn't in an approved docker repo, since it has not been updated in 2 years (and will be deprecated in the next release), we can just save a copy in our internal repo

Issues identified and resolved during investigation of https://github.com/StatCan/aaw-private/issues/95