### PR TITLE
chore(pdb): bring knative pdb to replicas-1

### DIFF
--- a/kustomize/common/knative/base/kustomization.yaml
+++ b/kustomize/common/knative/base/kustomization.yaml
@@ -64,7 +64,7 @@ patchesJson6902:
       group: policy
       version: v1
       kind: PodDisruptionBudget
-      name: 'activator-pdb|webhook-pdb'
+      name: 'activator-pdb|webhook-pdb|eventing-webhook'
     patch: |-
       - op: replace
         path: "/spec/minAvailable"

--- a/kustomize/common/knative/base/kustomization.yaml
+++ b/kustomize/common/knative/base/kustomization.yaml
@@ -62,7 +62,7 @@ patchesJson6902:
         value: 3
   - target:
       group: policy
-      version: v1
+      version: 'v1beta1|v1'
       kind: PodDisruptionBudget
       name: 'activator-pdb|webhook-pdb|eventing-webhook'
     patch: |-

--- a/kustomize/common/knative/base/kustomization.yaml
+++ b/kustomize/common/knative/base/kustomization.yaml
@@ -60,3 +60,12 @@ patchesJson6902:
       - op: replace
         path: "/spec/minReplicas"
         value: 3
+  - target:
+      group: policy
+      version: v1
+      kind: PodDisruptionBudget
+      name: 'activator-pdb|webhook-pdb'
+    patch: |-
+      - op: replace
+        path: "/spec/minAvailable"
+        value: 2


### PR DESCRIPTION
for https://github.com/StatCan/aaw/issues/1661

Tested and verified output by running the following command of `kustomize build > output.yaml` in   `kustomize/common/knative/base` and observed.

```
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  labels:
    app.kubernetes.io/component: activator
    app.kubernetes.io/name: knative-serving
    app.kubernetes.io/version: 1.2.5
    serving.knative.dev/release: v1.2.5
  name: activator-pdb
  namespace: knative-serving
spec:
  minAvailable: 2

apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  labels:
    app.kubernetes.io/component: webhook
    app.kubernetes.io/name: knative-serving
    app.kubernetes.io/version: 1.2.5
    serving.knative.dev/release: v1.2.5
  name: webhook-pdb
  namespace: knative-serving
spec:
  minAvailable: 2

apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
  labels:
    app.kubernetes.io/component: knative-eventing
    app.kubernetes.io/name: knative-eventing
    app.kubernetes.io/version: 1.2.4
    eventing.knative.dev/release: v1.2.4
    kustomize.component: knative
  name: eventing-webhook
  namespace: knative-eventing
spec:
  minAvailable: 2
```