### PR TITLE
added authorization policy patch for jwa

### DIFF
--- a/kustomize/apps/jupyter-web-app/base/authorizationpolicy.yaml
+++ b/kustomize/apps/jupyter-web-app/base/authorizationpolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: jupyter-web-app
+spec:
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/istio-system/sa/kubeflow-service-account
+  selector:
+    matchLabels:
+      app: jupyter-web-app

--- a/kustomize/apps/jupyter-web-app/base/kustomization.yaml
+++ b/kustomize/apps/jupyter-web-app/base/kustomization.yaml
@@ -10,6 +10,7 @@ patchesStrategicMerge:
 - cluster-role.yaml
 - deployment.yaml
 - vs.yaml
+- authorizationpolicy.yaml
 
 configMapGenerator:
 - files:


### PR DESCRIPTION
To fix issue in https://github.com/StatCan/aaw/issues/1752 about the "rbac: access denied"

Applies a patch to the jwa auth pol to point to the correct service account `kubeflow-service-account`.