### PR TITLE
fix: Remove comma for configfile

### DIFF
--- a/kustomize/contrib/kserve/base/inferenceservice-configmap.yaml
+++ b/kustomize/contrib/kserve/base/inferenceservice-configmap.yaml
@@ -7,5 +7,5 @@ data:
   ingress: |-
     {
         "ingressGateway" : "ingress-general-system/general-istio-ingress-gateway-https",
-        "ingressService" : "general.ingress-general-system.svc.cluster.local",
+        "ingressService" : "general.ingress-general-system.svc.cluster.local"
     }


### PR DESCRIPTION
Part of https://github.com/StatCan/aaw/issues/1762
This should fix the kserve problem. Which was tested in dev on argocd live manifest