### PR TITLE
chore(remove spark)

### DIFF
--- a/kustomize/contrib/spark/base/kustomization.yaml
+++ b/kustomize/contrib/spark/base/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-- github.com/kubeflow/manifests/contrib/spark/spark-operator/overlays/application?ref=v1.7.0

--- a/kustomize/stacks/aaw/kustomization.yaml
+++ b/kustomize/stacks/aaw/kustomization.yaml
@@ -43,6 +43,5 @@ resources:
 
 ## Kubeflow (contrib)
 
-- ../../contrib/spark/base
 - ../../contrib/seldon/base
 - ../../contrib/kserve/base

--- a/kustomize/stacks/argo/kubeflow.yaml
+++ b/kustomize/stacks/argo/kubeflow.yaml
@@ -56,9 +56,6 @@ spec:
       - app: seldon
         folder: apps
         version: main
-      - app: spark
-        folder: apps
-        version: main
       - app: kserve
         folder: apps
         version: main

--- a/kustomize/stacks/local/kustomization.yaml
+++ b/kustomize/stacks/local/kustomization.yaml
@@ -26,6 +26,5 @@ resources:
 
 ## Kubeflow (contrib)
 
-- ../../contrib/spark/base
 - ../../contrib/seldon/base
 - ../../contrib/kserve/base

--- a/kustomize/stacks/upstream/kustomization.yaml
+++ b/kustomize/stacks/upstream/kustomization.yaml
@@ -26,6 +26,5 @@ resources:
 
 ## Kubeflow (contrib)
 
-- ../../contrib/spark/base
 - ../../contrib/seldon/base
 - ../../contrib/kserve/base


### PR DESCRIPTION
Related to https://github.com/StatCan/aaw/issues/1762

This will remove spark as kubeflow is getting rid of it in their upcoming releases anyways.