### PR TITLE
fix(Dev): sas default tag

### DIFF
--- a/kustomize/apps/jupyter-web-app/base/configs/spawner_ui_config.yaml
+++ b/kustomize/apps/jupyter-web-app/base/configs/spawner_ui_config.yaml
@@ -55,9 +55,9 @@ spawnerFormDefaults:
     disabledMessage:
       en: "SAS is unavailable while non-employees have access to this profile."
       fr: "SAS n'est pas disponible lorsque des non-employés ont accès à ce profil."
-    value: k8scc01covidacr.azurecr.io/sas:latest    # The list of available standard container Images
+    value: k8scc01covidacr.azurecr.io/sas:v1    # The list of available standard container Images
     options:
-    - k8scc01covidacr.azurecr.io/sas:latest
+    - k8scc01covidacr.azurecr.io/sas:v1
   hideRegistry: true
   hideTag: true
   allowCustomImage: true


### PR DESCRIPTION
SAS default tag was `latest`, which means it can pull from The Zone if it's the newest version. 

This switches it to `v1` which is only for AAW images. 