### PR TITLE
fix(jupyter-apis): Add watch verb to cluster role for pods

### DIFF
--- a/kustomize/apps/jupyter-web-app/base/cluster-role.yaml
+++ b/kustomize/apps/jupyter-web-app/base/cluster-role.yaml
@@ -67,6 +67,7 @@ rules:
   verbs:
   - list
   - get
+  - watch
 
 ---
 


### PR DESCRIPTION
cc @EveningStarlight 

EX error: 
```
jupyter-web-app E1229 16:13:06.768970       1 reflector.go:166] "Unhandled Error" err="pkg/mod/k8s.io/client-go@v0.32.1/tools/cache/reflector.go:251: Failed to watch *v1.Pod: pods is forbidden: User \"system:serviceaccount:kubeflow:jupyter-web-app-service-account\" cannot wat 
ch resource \"pods\" in API group \"\" at the cluster scope" logger="UnhandledError" 
```